### PR TITLE
Remove shadow dom styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "private": true,
   "main": "./lib/main",
   "engines": {
-    "atom": ">=1.1.0 <2.0.0"
+    "atom": ">=1.13.0 <2.0.0"
   }
 }

--- a/styles/functions.less
+++ b/styles/functions.less
@@ -11,13 +11,11 @@
 }
 
 .editor-font (@fonts) {
-  atom-text-editor,
-  atom-text-editor::shadow {
+  atom-text-editor {
     font-family: @fonts;
   }
   .settings-view {
-    atom-text-editor.mini,
-    atom-text-editor.mini::shadow {
+    atom-text-editor.mini {
       font-family: @fonts !important;
     }
   }


### PR DESCRIPTION
The Shadow DOM got removed from text editors since Atom v1.13. See http://flight-manual.atom.io/shadow-dom/sections/removing-shadow-dom-styles/.
